### PR TITLE
fix target build in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 BINARY_NAME=cmd/main.out
 SOURCE_DIR=pkg/infra
 
-${BINARY_NAME}:
+all: run
+
+build:
 		cd ${SOURCE_DIR}; go mod tidy
 		go build -o ${BINARY_NAME} infra
-
-build: ${BINARY_NAME}
 
 run: build
 	  ${BINARY_NAME}


### PR DESCRIPTION
A quick fix to correct target `build` in Makefile

The current version of Makefile refuses to rerun build after source code been update.