### PR TITLE
[infra] Create API for individual team use

### DIFF
--- a/.github/workflows/run_game.yaml
+++ b/.github/workflows/run_game.yaml
@@ -37,11 +37,9 @@ jobs:
 
       - name: Build main.go to tmp directory
         run: make build BINARY_NAME=/tmp/infra
-        working-directory: pkg/infra
 
       - name: Build team 0 file
         run: make build BINARY_NAME=/tmp/team0 TEAM=0
-        working-directory: pkg/infra
 
       # Duplicate the following step, but rename the environment variable AGENT_RANDOM_QUANTITY to AGENT_{agent name}_QUANTITY to run
       # the game for your agent

--- a/.github/workflows/run_game.yaml
+++ b/.github/workflows/run_game.yaml
@@ -36,7 +36,11 @@ jobs:
           go-version-file: './pkg/infra/go.mod'
 
       - name: Build main.go to tmp directory
-        run: go build -o /tmp/infra
+        run: make build BINARY_NAME=/tmp/infra
+        working-directory: pkg/infra
+
+      - name: Build team 0 file
+        run: make build BINARY_NAME=/tmp/team0 TEAM=0
         working-directory: pkg/infra
 
       # Duplicate the following step, but rename the environment variable AGENT_RANDOM_QUANTITY to AGENT_{agent name}_QUANTITY to run
@@ -52,3 +56,7 @@ jobs:
           BASE_STAMINA: ${{ matrix.base_stamina }}
           THRESHOLD_PCT: ${{ matrix.threshold_pct }}
           AGENT_RANDOM_QUANTITY: ${{ matrix.agent_quantity }}
+
+      - name: Run Team0 program
+        run: ./team0
+        working-directory: /tmp

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-BINARY_NAME=cmd/main.out
+BINARY_NAME?=cmd/main.out
 SOURCE_DIR=pkg/infra
 TEAM?=default
-LDFLAGS=-ldflags="-X 'infra/game/api.mode=${TEAM}'"
+LDFLAGS=-ldflags="-X 'infra/game/stages.mode=${TEAM}'"
 
 all: run
 

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
 BINARY_NAME=cmd/main.out
 SOURCE_DIR=pkg/infra
+TEAM?=default
+LDFLAGS=-ldflags="-X 'infra/game/api.mode=${TEAM}'"
 
 all: run
 
 build:
 		cd ${SOURCE_DIR}; go mod tidy
-		go build -o ${BINARY_NAME} infra
+		go build $(LDFLAGS) -o ${BINARY_NAME} infra 
 
 run: build
 		${BINARY_NAME}

--- a/README.md
+++ b/README.md
@@ -15,10 +15,12 @@
 ```
 git clone git@github.com:SOMAS2022/SOMAS2022.git
 cd SOMAS2022
-make build
-make run
+make
 ```
-
+If running a team experiment, eg for team 0:
+```
+make TEAM=0
+```
 ## Project Structure
 
 Following some Golang Standards [[1]](https://github.com/golang-standards/project-layout), [[2]](https://medium.com/sellerapp/golang-project-structuring-ben-johnson-way-2a11035f94bc) and previous year project structures ([2021](https://github.com/SOMAS2021/SOMAS2021))
@@ -37,6 +39,8 @@ Following some Golang Standards [[1]](https://github.com/golang-standards/projec
 │   │   └── (Teams Agents)
 │   └── infra
 │       └── (Infrastructure Implementation)
+|       └── teams
+|           └── (Individual Team Experiments)
 └── scripts
     └── (Automation/Execution scripts)
 ```

--- a/pkg/infra/game/api/api.go
+++ b/pkg/infra/game/api/api.go
@@ -1,0 +1,34 @@
+package api
+
+import (
+	"infra/game/agent"
+	"infra/game/decision"
+	"infra/game/stage/fight"
+	"infra/game/stage/loot"
+	"infra/game/state"
+
+	"github.com/benbjohnson/immutable"
+
+	t0 "infra/teams/team0"
+)
+
+var mode = "default"
+
+// TODO: Change to using views
+func AllocateLoot(globalState state.State, weaponLoot []uint, shieldLoot []uint) (allocatedState state.State) {
+	switch mode {
+	case "0":
+		return t0.AllocateLoot(globalState, weaponLoot, shieldLoot)
+	default:
+		return loot.AllocateLoot(globalState, weaponLoot, shieldLoot)
+	}
+
+}
+func AgentFightDecisions(state *state.View, agents map[string]agent.Agent, previousDecisions *immutable.Map[string, decision.FightAction]) map[string]decision.FightAction {
+	switch mode {
+	case "0":
+		return t0.AllDefend(agents)
+	default:
+		return fight.AgentFightDecisions(state, agents, previousDecisions)
+	}
+}

--- a/pkg/infra/game/stage/fight/fight.go
+++ b/pkg/infra/game/stage/fight/fight.go
@@ -1,12 +1,13 @@
 package fight
 
 import (
-	"github.com/benbjohnson/immutable"
 	"infra/game/agent"
 	"infra/game/commons"
 	"infra/game/decision"
 	"infra/game/state"
 	"math"
+
+	"github.com/benbjohnson/immutable"
 )
 
 func DealDamage(attack uint, agentMap map[string]agent.Agent, globalState *state.State) {
@@ -30,19 +31,22 @@ func DealDamage(attack uint, agentMap map[string]agent.Agent, globalState *state
 	}
 }
 
-func HandleFightRound(state *state.State, agents map[string]agent.Agent, baseHealth uint, previousDecisions *immutable.Map[string, decision.FightAction]) (uint, uint, uint, map[string]decision.FightAction) {
+func AgentFightDecisions(state *state.View, agents map[string]agent.Agent, previousDecisions *immutable.Map[string, decision.FightAction]) map[string]decision.FightAction {
 	decisionMap := make(map[string]decision.FightAction)
 	channels := make(map[string]chan decision.FightAction)
 
-	view := state.ToView()
-
 	for i, a := range agents {
-		channels[i] = startAgentFightHandlers(view, a, previousDecisions)
+		channels[i] = startAgentFightHandlers(state, a, previousDecisions)
 	}
 	for i, dChan := range channels {
 		decisionMap[i] = <-dChan
 		close(dChan)
 	}
+
+	return decisionMap
+}
+
+func HandleFightRound(state *state.State, baseHealth uint, decisionMap map[string]decision.FightAction) (uint, uint, uint) {
 
 	var coweringAgents uint
 	var attackSum uint
@@ -80,7 +84,7 @@ func HandleFightRound(state *state.State, agents map[string]agent.Agent, baseHea
 		state.AgentState[agentID] = agentState
 	}
 
-	return coweringAgents, attackSum, shieldSum, decisionMap
+	return coweringAgents, attackSum, shieldSum
 }
 
 func startAgentFightHandlers(view *state.View, a agent.Agent, decisionLog *immutable.Map[string, decision.FightAction]) chan decision.FightAction {

--- a/pkg/infra/game/stage/loot/loot.go
+++ b/pkg/infra/game/stage/loot/loot.go
@@ -1,0 +1,24 @@
+package loot
+
+import (
+	"infra/game/commons"
+	"infra/game/state"
+	"math/rand"
+)
+
+func AllocateLoot(globalState state.State, weaponLoot []uint, shieldLoot []uint) (allocatedState state.State) {
+
+	allocatedState = globalState
+
+	for _, agentState := range allocatedState.AgentState {
+		allocatedWeapon := rand.Intn(len(weaponLoot))
+		allocatedShield := rand.Intn(len(shieldLoot))
+
+		agentState.BonusAttack = weaponLoot[allocatedWeapon]
+		agentState.BonusDefense = shieldLoot[allocatedShield]
+		weaponLoot, _ = commons.DeleteElFromSlice(weaponLoot, allocatedWeapon)
+		shieldLoot, _ = commons.DeleteElFromSlice(shieldLoot, allocatedShield)
+	}
+
+	return
+}

--- a/pkg/infra/game/stages/stages.go
+++ b/pkg/infra/game/stages/stages.go
@@ -1,4 +1,4 @@
-package api
+package stages
 
 import (
 	"infra/game/agent"
@@ -9,24 +9,27 @@ import (
 
 	"github.com/benbjohnson/immutable"
 
+	//? Add you team folder like this:
 	t0 "infra/teams/team0"
 )
 
+// ? Changed at compile time. eg run with `make TEAM=0` to set this to '0'
 var mode = "default"
 
 // TODO: Change to using views
-func AllocateLoot(globalState state.State, weaponLoot []uint, shieldLoot []uint) (allocatedState state.State) {
+func AgentLootDecisions(globalState state.State, agents map[string]agent.Agent, weaponLoot []uint, shieldLoot []uint) (allocatedState state.State) {
 	switch mode {
 	case "0":
 		return t0.AllocateLoot(globalState, weaponLoot, shieldLoot)
 	default:
 		return loot.AllocateLoot(globalState, weaponLoot, shieldLoot)
 	}
-
 }
+
 func AgentFightDecisions(state *state.View, agents map[string]agent.Agent, previousDecisions *immutable.Map[string, decision.FightAction]) map[string]decision.FightAction {
 	switch mode {
 	case "0":
+		//? Not necessary to use all function arguments
 		return t0.AllDefend(agents)
 	default:
 		return fight.AgentFightDecisions(state, agents, previousDecisions)

--- a/pkg/infra/main.go
+++ b/pkg/infra/main.go
@@ -4,18 +4,17 @@ import (
 	"flag"
 	"infra/config"
 	"infra/game/agent"
-	"infra/game/api"
 	"infra/game/commons"
 	"infra/game/decision"
 	gamemath "infra/game/math"
 	"infra/game/stage/fight"
+	"infra/game/stages"
 	"infra/game/state"
 	"infra/logging"
 	"math"
 	"math/rand"
 
 	"github.com/benbjohnson/immutable"
-
 	"github.com/google/uuid"
 	"github.com/joho/godotenv"
 )
@@ -50,7 +49,7 @@ func gameLoop(globalState state.State, agentMap map[string]agent.Agent, gameConf
 			for u, action := range decisionMap {
 				decisionMapView.Set(u, action)
 			}
-			dMap := api.AgentFightDecisions(globalState.ToView(), agentMap, decisionMapView.Map())
+			dMap := stages.AgentFightDecisions(globalState.ToView(), agentMap, decisionMapView.Map())
 			coweringAgents, attackSum, shieldSum := fight.HandleFightRound(&globalState, gameConfig.StartingHealthPoints, dMap)
 			decisionMap = dMap
 
@@ -95,7 +94,8 @@ func gameLoop(globalState state.State, agentMap map[string]agent.Agent, gameConf
 			shieldLoot[i] = globalState.CurrentLevel * uint(rand.Intn(3))
 		}
 
-		new_global_state := api.AllocateLoot(globalState, weaponLoot, shieldLoot)
+		new_global_state := stages.AgentLootDecisions(globalState, weaponLoot, shieldLoot)
+		// TODO: Add verification if needed
 		globalState = new_global_state
 
 	}

--- a/pkg/infra/main.go
+++ b/pkg/infra/main.go
@@ -94,7 +94,7 @@ func gameLoop(globalState state.State, agentMap map[string]agent.Agent, gameConf
 			shieldLoot[i] = globalState.CurrentLevel * uint(rand.Intn(3))
 		}
 
-		new_global_state := stages.AgentLootDecisions(globalState, weaponLoot, shieldLoot)
+		new_global_state := stages.AgentLootDecisions(globalState, agentMap, weaponLoot, shieldLoot)
 		// TODO: Add verification if needed
 		globalState = new_global_state
 

--- a/pkg/infra/teams/team0/fight_decisions.go
+++ b/pkg/infra/teams/team0/fight_decisions.go
@@ -1,0 +1,16 @@
+package team0
+
+import (
+	"infra/game/agent"
+	"infra/game/decision"
+)
+
+func AllDefend(agents map[string]agent.Agent) map[string]decision.FightAction {
+	decisionMap := make(map[string]decision.FightAction)
+
+	for i, _ := range agents {
+		decisionMap[i] = decision.Defend
+	}
+
+	return decisionMap
+}

--- a/pkg/infra/teams/team0/weapon_alloc.go
+++ b/pkg/infra/teams/team0/weapon_alloc.go
@@ -1,0 +1,27 @@
+package team0
+
+import (
+	"infra/game/commons"
+	"infra/game/state"
+	"math/rand"
+)
+
+/**
+* This default function allocates loot randomly
+ */
+func AllocateLoot(globalState state.State, weaponLoot []uint, shieldLoot []uint) (allocatedState state.State) {
+
+	allocatedState = globalState
+
+	for _, agentState := range allocatedState.AgentState {
+		allocatedWeapon := rand.Intn(len(weaponLoot))
+		allocatedShield := rand.Intn(len(shieldLoot))
+
+		agentState.BonusAttack = weaponLoot[allocatedWeapon]
+		agentState.BonusDefense = shieldLoot[allocatedShield]
+		weaponLoot, _ = commons.DeleteElFromSlice(weaponLoot, allocatedWeapon)
+		shieldLoot, _ = commons.DeleteElFromSlice(shieldLoot, allocatedShield)
+	}
+
+	return
+}

--- a/pkg/infra/teams/team0/weapon_alloc.go
+++ b/pkg/infra/teams/team0/weapon_alloc.go
@@ -9,9 +9,9 @@ import (
 /**
 * This default function allocates loot randomly
  */
-func AllocateLoot(globalState state.State, weaponLoot []uint, shieldLoot []uint) (allocatedState state.State) {
+func AllocateLoot(globalState state.State, weaponLoot []uint, shieldLoot []uint) state.State {
 
-	allocatedState = globalState
+	allocatedState := globalState
 
 	for _, agentState := range allocatedState.AgentState {
 		allocatedWeapon := rand.Intn(len(weaponLoot))
@@ -23,5 +23,5 @@ func AllocateLoot(globalState state.State, weaponLoot []uint, shieldLoot []uint)
 		shieldLoot, _ = commons.DeleteElFromSlice(shieldLoot, allocatedShield)
 	}
 
-	return
+	return allocatedState
 }


### PR DESCRIPTION
This change creates some high level API functions that are called in main() to get agent fight decisions or loot allocation decisions. These would normally work the same way as before by calling back into infra code.

However, should a team wish to specialise these functions they can do so by adding their own files in "infra/game/teams/teamX" with package name teamX, and run the game with `make TEAM=X` to run the game with their own functions. This would be useful for individual team experiments.

Example files are shown here with a fictitious "Team 0" and can be built with `make TEAM=0`