### PR TITLE
[infra] Extend logging to aid agent development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,9 @@ run: build
 
 runWithJSON: build
 		${BINARY_NAME} -j
- 
+
+runDebug: build
+		${BINARY_NAME} -d
 clean:
 		go clean
 		rm -rf ${BINARY_NAME}

--- a/pkg/infra/config/environment_helpers.go
+++ b/pkg/infra/config/environment_helpers.go
@@ -1,7 +1,8 @@
 package config
 
 import (
-	"log"
+	"fmt"
+	"infra/logging"
 	"os"
 	"strconv"
 )
@@ -9,7 +10,7 @@ import (
 func EnvToUint(key string, def uint) uint {
 	levels, err := strconv.ParseUint(os.Getenv(key), 10, 0)
 	if err != nil {
-		log.Printf("%s unset, defaulting to %d\n", key, def)
+		logging.Log(logging.Warn, nil, fmt.Sprintf("%s unset, defaulting to %d\n", key, def))
 		return def
 	}
 	return uint(levels)
@@ -18,7 +19,7 @@ func EnvToUint(key string, def uint) uint {
 func EnvToFloat(key string, def float32) float32 {
 	levels, err := strconv.ParseFloat(os.Getenv(key), 32)
 	if err != nil {
-		log.Printf("%s unset, defaulting to %f\n", key, def)
+		logging.Log(logging.Warn, nil, fmt.Sprintf("%s unset, defaulting to %f\n", key, def))
 		return def
 	}
 	return float32(levels)

--- a/pkg/infra/game/agent/agent.go
+++ b/pkg/infra/game/agent/agent.go
@@ -7,6 +7,7 @@ import (
 	"infra/game/decision"
 	"infra/game/message"
 	"infra/game/state"
+	"infra/logging"
 	"sync"
 )
 
@@ -45,13 +46,23 @@ func (a *Agent) handleMessage(view *state.View, log *immutable.Map[commons.ID, d
 	return decision.Undecided
 }
 
+func (ba *BaseAgent) log(lvl logging.Level, fields logging.LogField, msg string) {
+	agentFields := logging.LogField{
+		"agentName": ba.AgentName,
+		"agentID":   ba.Id,
+	}
+
+	logging.Log(lvl, logging.CombineFields(agentFields, fields), msg)
+}
+
 type BaseAgent struct {
 	communication Communication
 	Id            commons.ID
+	AgentName     string
 }
 
-func NewBaseAgent(communication Communication, id commons.ID) BaseAgent {
-	return BaseAgent{communication: communication, Id: id}
+func NewBaseAgent(communication Communication, id commons.ID, agentName string) BaseAgent {
+	return BaseAgent{communication: communication, Id: id, AgentName: agentName}
 }
 
 type Communication struct {

--- a/pkg/infra/game/agent/random.go
+++ b/pkg/infra/game/agent/random.go
@@ -6,6 +6,7 @@ import (
 	"infra/game/decision"
 	"infra/game/message"
 	"infra/game/state"
+	"infra/logging"
 	"math/rand"
 )
 
@@ -24,9 +25,9 @@ func NewRandomAgent() *RandomAgent {
 
 func (r RandomAgent) HandleFightMessage(m message.TaggedMessage, view *state.View, agent BaseAgent, log *immutable.Map[commons.ID, decision.FightAction]) decision.FightAction {
 	fight := rand.Intn(3)
-
 	switch fight {
 	case 0:
+		agent.log(logging.Trace, logging.LogField{"bravery": r.bravery}, "Cowering")
 		return decision.Cower
 	case 1:
 		return decision.Attack

--- a/pkg/infra/go.mod
+++ b/pkg/infra/go.mod
@@ -4,13 +4,11 @@ go 1.19
 
 require github.com/sirupsen/logrus v1.9.0
 
-require (
-	golang.org/x/exp v0.0.0-20220518171630-0b5c67f07fdf // indirect
-	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
-)
+require golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
 
 require (
 	github.com/benbjohnson/immutable v0.4.0
 	github.com/google/uuid v1.3.0
 	github.com/joho/godotenv v1.4.0
+	golang.org/x/exp v0.0.0-20220518171630-0b5c67f07fdf
 )

--- a/pkg/infra/logging/logging.go
+++ b/pkg/infra/logging/logging.go
@@ -21,14 +21,13 @@ const (
 
 func InitLogger(useJSONFormatter bool, debug bool) {
 	if useJSONFormatter {
-		// Log as JSON instead of the default ASCII formatter.
 		log.SetFormatter(&logrus.JSONFormatter{})
 	} else {
 		log.SetFormatter(&logrus.TextFormatter{})
 	}
-	// Output to stdout instead of the default stderr
+
 	log.SetOutput(os.Stdout)
-	// Only log the warning severity or above.
+
 	if debug {
 		log.SetLevel(logrus.TraceLevel)
 	} else {

--- a/pkg/infra/logging/logging.go
+++ b/pkg/infra/logging/logging.go
@@ -1,6 +1,7 @@
 package logging
 
 import (
+	"fmt"
 	"github.com/sirupsen/logrus"
 	"os"
 )
@@ -31,12 +32,13 @@ func InitLogger(useJSONFormatter bool, debug bool) {
 	if debug {
 		log.SetLevel(logrus.TraceLevel)
 	} else {
+		Log(Warn, nil, "'Trace' and 'Debug' messages hidden. Run with '-d' or 'make runDebug' to see these logs.")
 		log.SetLevel(logrus.InfoLevel)
 	}
 }
 
-func Log(err Level, fields LogField, msg string) {
-	switch err {
+func Log(lvl Level, fields LogField, msg string) {
+	switch lvl {
 	case Trace:
 		log.WithFields(fields).Trace(msg)
 	case Debug:
@@ -50,4 +52,14 @@ func Log(err Level, fields LogField, msg string) {
 	default:
 		log.WithFields(fields).Info(msg)
 	}
+}
+
+func CombineFields(a LogField, b LogField) LogField {
+	for k, v := range b {
+		if a[k] != nil {
+			Log(Warn, nil, fmt.Sprintf("Overwriting '%s' default logging field to '%s'", k, v))
+		}
+		a[k] = v
+	}
+	return a
 }

--- a/pkg/infra/logging/logging.go
+++ b/pkg/infra/logging/logging.go
@@ -5,19 +5,50 @@ import (
 	"os"
 )
 
-var Log = logrus.New()
+var log = logrus.New()
 
 type LogField = logrus.Fields
 
-func InitLogger(useJSONFormatter bool) {
+type Level uint32
+
+const (
+	Trace = iota
+	Debug
+	Info
+	Warn
+	Error
+)
+
+func InitLogger(useJSONFormatter bool, debug bool) {
 	if useJSONFormatter {
 		// Log as JSON instead of the default ASCII formatter.
-		Log.SetFormatter(&logrus.JSONFormatter{})
+		log.SetFormatter(&logrus.JSONFormatter{})
 	} else {
-		Log.SetFormatter(&logrus.TextFormatter{})
+		log.SetFormatter(&logrus.TextFormatter{})
 	}
 	// Output to stdout instead of the default stderr
-	Log.SetOutput(os.Stdout)
+	log.SetOutput(os.Stdout)
 	// Only log the warning severity or above.
-	Log.SetLevel(logrus.DebugLevel)
+	if debug {
+		log.SetLevel(logrus.TraceLevel)
+	} else {
+		log.SetLevel(logrus.InfoLevel)
+	}
+}
+
+func Log(err Level, fields LogField, msg string) {
+	switch err {
+	case Trace:
+		log.WithFields(fields).Trace(msg)
+	case Debug:
+		log.WithFields(fields).Debug(msg)
+	case Info:
+		log.WithFields(fields).Info(msg)
+	case Warn:
+		log.WithFields(fields).Warn(msg)
+	case Error:
+		log.WithFields(fields).Error(msg)
+	default:
+		log.WithFields(fields).Info(msg)
+	}
 }

--- a/pkg/infra/main.go
+++ b/pkg/infra/main.go
@@ -31,10 +31,11 @@ Enables peers to send and receive messages with broadcasting possible via non-bl
 
 func main() {
 	// define flags
-	useJSONFormatter := flag.Bool("j", false, "whether to use JSONFormatter for logging")
+	useJSONFormatter := flag.Bool("j", false, "Whether to output logs in JSON")
+	debug := flag.Bool("d", false, "Whether to run in debug mode. If false, only logs with level info or above will be shown")
 	flag.Parse()
 
-	logging.InitLogger(*useJSONFormatter)
+	logging.InitLogger(*useJSONFormatter, *debug)
 
 	agentMap, globalState, gameConfig := initialise()
 	gameLoop(globalState, agentMap, gameConfig)
@@ -54,7 +55,7 @@ func gameLoop(globalState state.State, agentMap map[commons.ID]agent.Agent, game
 			coweringAgents, attackSum, shieldSum, dMap := fight.HandleFightRound(globalState, agentMap, gameConfig.StartingHealthPoints, *decisionMapView.Map(), channelsMap)
 			decisionMap = dMap
 
-			logging.Log.WithFields(logging.LogField{
+			logging.Log(logging.Trace, logging.LogField{
 				"currLevel":     globalState.CurrentLevel,
 				"monsterHealth": globalState.MonsterHealth,
 				"monsterDamage": globalState.MonsterAttack,
@@ -62,7 +63,8 @@ func gameLoop(globalState state.State, agentMap map[commons.ID]agent.Agent, game
 				"attackSum":     attackSum,
 				"shieldSum":     shieldSum,
 				"numAgents":     len(agentMap),
-			}).Info("Battle summary")
+			}, "Battle Summary")
+			// logging.Log.WithFields().Info("Battle summary")
 			if coweringAgents == uint(len(agentMap)) {
 				attack := globalState.MonsterAttack
 				fight.DealDamage(attack, agentMap, &globalState)
@@ -78,7 +80,7 @@ func gameLoop(globalState state.State, agentMap map[commons.ID]agent.Agent, game
 			channelsMap = addCommsChannels(agentMap)
 
 			if float64(len(agentMap)) < math.Ceil(float64(gameConfig.ThresholdPercentage)*float64(gameConfig.InitialNumAgents)) {
-				logging.Log.Infof("Lost on level %d  with %d remaining", globalState.CurrentLevel, len(agentMap))
+				// logging.Log.Infof("Lost on level %d  with %d remaining", globalState.CurrentLevel, len(agentMap))
 				return
 			}
 		}
@@ -118,7 +120,7 @@ func initialise() (map[commons.ID]agent.Agent, state.State, config.GameConfig) {
 
 	err := godotenv.Load()
 	if err != nil {
-		logging.Log.Warnln("No .env file located, using defaults")
+		// logging.Log.Warnln("No .env file located, using defaults")
 	}
 
 	gameConfig := config.GameConfig{

--- a/pkg/infra/main.go
+++ b/pkg/infra/main.go
@@ -138,7 +138,7 @@ func initialise() (map[commons.ID]agent.Agent, state.State, config.GameConfig) {
 		quantity := config.EnvToUint(expectedEnvName, 0)
 
 		gameConfig.InitialNumAgents += quantity
-		instantiateAgent(gameConfig, agentMap, agentStateMap, quantity, strategy)
+		instantiateAgent(gameConfig, agentMap, agentStateMap, quantity, strategy, agentName)
 	}
 
 	globalState := state.State{
@@ -163,7 +163,7 @@ func addCommsChannels(agentMap map[commons.ID]agent.Agent) (res map[commons.ID]c
 	}
 	immutableMap := createImmutableMap(res)
 	for id, a := range agentMap {
-		a.BaseAgent = agent.NewBaseAgent(agent.NewCommunication(res[id], *immutableMap.Delete(id)), id)
+		a.BaseAgent = agent.NewBaseAgent(agent.NewCommunication(res[id], *immutableMap.Delete(id)), id, a.BaseAgent.AgentName)
 		agentMap[id] = a
 	}
 	return
@@ -181,12 +181,14 @@ func instantiateAgent[S agent.Strategy](gameConfig config.GameConfig,
 	agentMap map[commons.ID]agent.Agent,
 	agentStateMap map[commons.ID]state.AgentState,
 	quantity uint,
-	strategy S) {
+	strategy S,
+	agentName string,
+) {
 	for i := uint(0); i < quantity; i++ {
 		// TODO: add peer channels
 		agentId := uuid.New().String()
 		agentMap[agentId] = agent.Agent{
-			BaseAgent: agent.BaseAgent{},
+			BaseAgent: agent.BaseAgent{AgentName: agentName},
 			Strategy:  strategy,
 		}
 

--- a/pkg/infra/main.go
+++ b/pkg/infra/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"github.com/benbjohnson/immutable"
 	"infra/config"
 	"infra/game/agent"
@@ -55,7 +56,7 @@ func gameLoop(globalState state.State, agentMap map[commons.ID]agent.Agent, game
 			coweringAgents, attackSum, shieldSum, dMap := fight.HandleFightRound(globalState, agentMap, gameConfig.StartingHealthPoints, *decisionMapView.Map(), channelsMap)
 			decisionMap = dMap
 
-			logging.Log(logging.Trace, logging.LogField{
+			logging.Log(logging.Info, logging.LogField{
 				"currLevel":     globalState.CurrentLevel,
 				"monsterHealth": globalState.MonsterHealth,
 				"monsterDamage": globalState.MonsterAttack,
@@ -64,7 +65,6 @@ func gameLoop(globalState state.State, agentMap map[commons.ID]agent.Agent, game
 				"shieldSum":     shieldSum,
 				"numAgents":     len(agentMap),
 			}, "Battle Summary")
-			// logging.Log.WithFields().Info("Battle summary")
 			if coweringAgents == uint(len(agentMap)) {
 				attack := globalState.MonsterAttack
 				fight.DealDamage(attack, agentMap, &globalState)
@@ -80,7 +80,7 @@ func gameLoop(globalState state.State, agentMap map[commons.ID]agent.Agent, game
 			channelsMap = addCommsChannels(agentMap)
 
 			if float64(len(agentMap)) < math.Ceil(float64(gameConfig.ThresholdPercentage)*float64(gameConfig.InitialNumAgents)) {
-				// logging.Log.Infof("Lost on level %d  with %d remaining", globalState.CurrentLevel, len(agentMap))
+				logging.Log(logging.Info, nil, fmt.Sprintf("Lost on level %d  with %d remaining", globalState.CurrentLevel, len(agentMap)))
 				return
 			}
 		}
@@ -120,7 +120,7 @@ func initialise() (map[commons.ID]agent.Agent, state.State, config.GameConfig) {
 
 	err := godotenv.Load()
 	if err != nil {
-		// logging.Log.Warnln("No .env file located, using defaults")
+		logging.Log(logging.Error, nil, "No .env file located, using defaults")
 	}
 
 	gameConfig := config.GameConfig{


### PR DESCRIPTION
Still a WIP but shouldn't take that long to do.

The goal is to extend the work done in #8 to provide agent teams with more utility when developing/debugging their agents. These include:

- [x] A `runDebug` Makefile config that enables `Trace` and `Debug` level messages to be logged - these are disabled for 'real' runs to improve performance and reduce clutter. If agent teams want to see what is happening within their agents for development, these are the levels they should use. 

For clarity, when not using `runDebug`, only `Info`, `Warn`, and `Error` messages will be shown - these should be used for critical global knowledge (level summaries, potentially voting results etc) because it will get out of control if all 23908592 agents produce these logs.

- [x] Abstract the logger away from agent teams to reduce the chance of misuse and increase simplicity. For example, not providing access to `fatal` and `panic` levels which Logrus does provide.
- [x] (Maybe) provide the BaseAgent with a logging function that automatically fills in some basic info such as which agent is producing the log so this is shown even if agent teams forget to do so. 