### PR TITLE
Deal damage only to agents not cowering, unless they're all cowering in which case deal damage to them all

### DIFF
--- a/pkg/infra/game/decision/result.go
+++ b/pkg/infra/game/decision/result.go
@@ -1,0 +1,14 @@
+package decision
+
+import (
+	"infra/game/commons"
+)
+
+type FightResult struct {
+	Choices         map[commons.ID]FightAction
+	AttackingAgents []commons.ID
+	ShieldingAgents []commons.ID
+	CoweringAgents  []commons.ID
+	AttackSum       uint
+	ShieldSum       uint
+}

--- a/pkg/infra/game/stage/fight/fight.go
+++ b/pkg/infra/game/stage/fight/fight.go
@@ -11,18 +11,19 @@ import (
 	"sync"
 )
 
-func DealDamage(attack uint, agentMap map[commons.ID]agent.Agent, globalState *state.State) {
-	splitDamage := attack / uint(len(agentMap))
-	for id, agentState := range globalState.AgentState {
-		newHp := commons.SaturatingSub(agentState.Hp, splitDamage)
-		if newHp == 0 {
+func DealDamage(damageToDeal uint, agentsFighting []string, agentMap map[commons.ID]agent.Agent, globalState *state.State) {
+	splitDamage := damageToDeal / uint(len(agentsFighting))
+	for _, id := range agentsFighting {
+		agentState := globalState.AgentState[id]
+		newHP := commons.SaturatingSub(agentState.Hp, splitDamage)
+		if newHP == 0 {
 			// kill agent
 			// todo: prune peer channels somehow...
 			delete(globalState.AgentState, id)
 			delete(agentMap, id)
 		} else {
 			globalState.AgentState[id] = state.AgentState{
-				Hp:           newHp,
+				Hp:           newHP,
 				Attack:       agentState.Attack,
 				Defense:      agentState.Defense,
 				BonusAttack:  agentState.BonusAttack,
@@ -68,9 +69,11 @@ func AgentFightDecisions(state *state.View, agents map[commons.ID]agent.Agent, p
 	return decisionMap
 }
 
-func HandleFightRound(state *state.State, baseHealth uint, decisionMap map[commons.ID]decision.FightAction) (uint, uint, uint) {
+func HandleFightRound(state *state.State, baseHealth uint, decisionMap map[commons.ID]decision.FightAction) ([]string, []string, []string, uint, uint) {
 
-	var coweringAgents uint
+	var attackingAgents []string
+	var defendingAgents []string
+	var coweringAgents []string
 	var attackSum uint
 	var shieldSum uint
 
@@ -80,33 +83,35 @@ func HandleFightRound(state *state.State, baseHealth uint, decisionMap map[commo
 		switch d {
 		case decision.Attack:
 			if agentState.Stamina > agentState.BonusAttack {
+				attackingAgents = append(attackingAgents, agentID)
 				attackSum += agentState.TotalAttack()
 				agentState.Stamina = commons.SaturatingSub(agentState.Stamina, agentState.BonusAttack)
 			} else {
-				coweringAgents++
+				coweringAgents = append(coweringAgents, agentID)
 				decisionMap[agentID] = decision.Cower
 				agentState.Hp += uint(math.Ceil(0.05 * float64(baseHealth)))
 				agentState.Stamina += 1
 			}
 		case decision.Defend:
 			if agentState.Stamina > agentState.BonusDefense {
+				defendingAgents = append(defendingAgents, agentID)
 				shieldSum += agentState.TotalDefense()
 				agentState.Stamina = commons.SaturatingSub(agentState.Stamina, agentState.BonusDefense)
 			} else {
-				coweringAgents++
+				coweringAgents = append(coweringAgents, agentID)
 				decisionMap[agentID] = decision.Cower
 				agentState.Hp += uint(math.Ceil(0.05 * float64(baseHealth)))
 				agentState.Stamina += 1
 			}
 		case decision.Cower:
-			coweringAgents++
+			coweringAgents = append(coweringAgents, agentID)
 			agentState.Hp += uint(math.Ceil(0.05 * float64(baseHealth)))
 			agentState.Stamina += 1
 		}
 		state.AgentState[agentID] = agentState
 	}
 
-	return coweringAgents, attackSum, shieldSum
+	return attackingAgents, defendingAgents, coweringAgents, attackSum, shieldSum
 }
 
 func startAgentFightHandlers(view state.View, a *agent.Agent, decisionLog immutable.Map[commons.ID, decision.FightAction], channel chan message.ActionMessage, wg *sync.WaitGroup) {

--- a/pkg/infra/main.go
+++ b/pkg/infra/main.go
@@ -54,31 +54,31 @@ func gameLoop(globalState state.State, agentMap map[commons.ID]agent.Agent, game
 			for u, action := range decisionMap {
 				decisionMapView.Set(u, action)
 			}
-			dMap := stages.AgentFightDecisions(globalState.ToView(), agentMap, *decisionMapView.Map(), channelsMap)
-			attackingAgents, defendingAgents, coweringAgents, attackSum, shieldSum := fight.HandleFightRound(&globalState, gameConfig.StartingHealthPoints, dMap)
-			decisionMap = dMap
+			fightRoundResult := decision.FightResult{Choices: stages.AgentFightDecisions(globalState.ToView(), agentMap, *decisionMapView.Map(), channelsMap)}
+			fight.HandleFightRound(&globalState, gameConfig.StartingHealthPoints, &fightRoundResult)
+			// decisionMap = dMap
 
 			logging.Log(logging.Info, logging.LogField{
 				"currLevel":     globalState.CurrentLevel,
 				"monsterHealth": globalState.MonsterHealth,
 				"monsterDamage": globalState.MonsterAttack,
-				"numCoward":     len(coweringAgents),
-				"attackSum":     attackSum,
-				"shieldSum":     shieldSum,
+				"numCoward":     len(fightRoundResult.CoweringAgents),
+				"attackSum":     fightRoundResult.AttackSum,
+				"shieldSum":     fightRoundResult.ShieldSum,
 				"numAgents":     len(agentMap),
 			}, "Battle Summary")
 
-			if len(coweringAgents) != len(agentMap) {
-				globalState.MonsterHealth = commons.SaturatingSub(globalState.MonsterHealth, attackSum)
+			if len(fightRoundResult.CoweringAgents) != len(agentMap) {
+				globalState.MonsterHealth = commons.SaturatingSub(globalState.MonsterHealth, fightRoundResult.AttackSum)
 				if globalState.MonsterHealth > 0 {
-					agentsFighting := append(attackingAgents, defendingAgents...)
-					damageTaken := globalState.MonsterAttack - shieldSum
+					agentsFighting := append(fightRoundResult.AttackingAgents, fightRoundResult.ShieldingAgents...)
+					damageTaken := globalState.MonsterAttack - fightRoundResult.ShieldSum
 					fight.DealDamage(damageTaken, agentsFighting, agentMap, &globalState)
 					// TODO: Monster disruptive ability
 				}
 			} else {
 				damageTaken := globalState.MonsterAttack
-				fight.DealDamage(damageTaken, coweringAgents, agentMap, &globalState)
+				fight.DealDamage(damageTaken, fightRoundResult.CoweringAgents, agentMap, &globalState)
 			}
 
 			channelsMap = addCommsChannels(agentMap)

--- a/pkg/infra/main.go
+++ b/pkg/infra/main.go
@@ -76,6 +76,9 @@ func gameLoop(globalState state.State, agentMap map[commons.ID]agent.Agent, game
 					fight.DealDamage(damageTaken, agentsFighting, agentMap, &globalState)
 					// TODO: Monster disruptive ability
 				}
+			} else {
+				damageTaken := globalState.MonsterAttack
+				fight.DealDamage(damageTaken, coweringAgents, agentMap, &globalState)
 			}
 
 			channelsMap = addCommsChannels(agentMap)


### PR DESCRIPTION
A quick fix to #55 to only deal damage to agents not cowering. 

This raises an issue where we now need to implement an upper level of rounds per level to ensure that agents can't all cower indefinitely to take no damage.