### PR TITLE
Globally accessible copies of game config

### DIFF
--- a/pkg/infra/config/types.go
+++ b/pkg/infra/config/types.go
@@ -1,5 +1,7 @@
 package config
 
+import "infra/logging"
+
 type GameConfig struct {
 	Initialised            bool
 	NumLevels              uint
@@ -15,6 +17,9 @@ var config = GameConfig{}
 
 func InitConfig(values GameConfig) {
 	if config.Initialised {
+		logging.Log(logging.Error, logging.LogField{
+			"levels": values.NumLevels,
+		}, "Trying to reinitialise GameConfig")
 		return
 	}
 

--- a/pkg/infra/config/types.go
+++ b/pkg/infra/config/types.go
@@ -1,6 +1,7 @@
 package config
 
 type GameConfig struct {
+	Initialised            bool
 	NumLevels              uint
 	StartingHealthPoints   uint
 	StartingAttackStrength uint
@@ -8,4 +9,27 @@ type GameConfig struct {
 	ThresholdPercentage    float32
 	InitialNumAgents       uint
 	Stamina                uint
+}
+
+var config = GameConfig{}
+
+func InitConfig(values GameConfig) {
+	if config.Initialised {
+		return
+	}
+
+	config = GameConfig{
+		Initialised:            true,
+		NumLevels:              values.NumLevels,
+		StartingHealthPoints:   values.StartingHealthPoints,
+		StartingAttackStrength: values.StartingAttackStrength,
+		StartingShieldStrength: values.StartingShieldStrength,
+		ThresholdPercentage:    values.ThresholdPercentage,
+		InitialNumAgents:       values.InitialNumAgents,
+		Stamina:                values.Stamina,
+	}
+}
+
+func ViewConfig() GameConfig {
+	return config
 }

--- a/pkg/infra/game/agent/random.go
+++ b/pkg/infra/game/agent/random.go
@@ -20,8 +20,8 @@ func (r RandomAgent) Default() decision.FightAction {
 	panic("implement me")
 }
 
-func NewRandomAgent() *RandomAgent {
-	return &RandomAgent{bravery: 0}
+func NewRandomAgent() Strategy {
+	return &RandomAgent{bravery: 10}
 }
 
 func (r RandomAgent) HandleFightMessage(m message.TaggedMessage, view *state.View, agent BaseAgent, log *immutable.Map[commons.ID, decision.FightAction]) decision.FightAction {

--- a/pkg/infra/main.go
+++ b/pkg/infra/main.go
@@ -21,8 +21,8 @@ import (
 	"github.com/joho/godotenv"
 )
 
-var InitAgentMap = map[commons.ID]agent.Strategy{
-	"RANDOM": agent.NewRandomAgent(),
+var InitAgentMap = map[commons.ID]func() agent.Strategy{
+	"RANDOM": agent.NewRandomAgent,
 }
 
 /*
@@ -136,7 +136,7 @@ func initialise() (map[commons.ID]agent.Agent, state.State) {
 		quantity := config.EnvToUint(expectedEnvName, 100)
 
 		gameConfig.InitialNumAgents += quantity
-		instantiateAgent(gameConfig, agentMap, agentStateMap, quantity, strategy, agentName)
+		defer instantiateAgent(gameConfig, agentMap, agentStateMap, quantity, strategy, agentName)
 	}
 
 	globalState := state.State{
@@ -177,7 +177,7 @@ func createImmutableMap(peerChannels map[commons.ID]chan message.TaggedMessage) 
 	return *builder.Map()
 }
 
-func instantiateAgent[S agent.Strategy](gameConfig config.GameConfig,
+func instantiateAgent[S func() agent.Strategy](gameConfig config.GameConfig,
 	agentMap map[commons.ID]agent.Agent,
 	agentStateMap map[commons.ID]state.AgentState,
 	quantity uint,
@@ -189,7 +189,7 @@ func instantiateAgent[S agent.Strategy](gameConfig config.GameConfig,
 		agentId := uuid.New().String()
 		agentMap[agentId] = agent.Agent{
 			BaseAgent: agent.BaseAgent{AgentName: agentName},
-			Strategy:  strategy,
+			Strategy:  strategy(),
 		}
 
 		agentStateMap[agentId] = state.AgentState{


### PR DESCRIPTION
At the moment the game config is passed around to functions as a parameter. I think it is cleaner if we keep one `config` object and then create copies when required. 

Also useful because these values might (and probably will) be needed in all over code and might be hard to get the values where they're needed.

Conversely, this would allow agents to see these values which may/may not be wanted!?