### PR TITLE
Fix infinite recursive call when accessing message sender

### DIFF
--- a/pkg/infra/game/message/message.go
+++ b/pkg/infra/game/message/message.go
@@ -47,7 +47,7 @@ func NewTaggedMessage(sender commons.ID, message Message, mId uuid.UUID) *Tagged
 }
 
 func (t TaggedMessage) Sender() commons.ID {
-	return t.Sender()
+	return t.sender
 }
 
 func (t TaggedMessage) Message() Message {


### PR DESCRIPTION
Fixed a bug that was causing a stack overflow via infinite recursion 