### PR TITLE
Add HP Pool (Logic + Donations)

### DIFF
--- a/pkg/infra/game/agent/agent.go
+++ b/pkg/infra/game/agent/agent.go
@@ -16,7 +16,6 @@ type Agent struct {
 }
 
 func (a *Agent) HandleDonateToHpPool(agentState state.AgentState) uint {
-	// fmt.Print(agentState)
 	a.BaseAgent.latestState = agentState
 
 	return a.Strategy.DonateToHpPool(a.BaseAgent)

--- a/pkg/infra/game/agent/agent.go
+++ b/pkg/infra/game/agent/agent.go
@@ -15,6 +15,19 @@ type Agent struct {
 	Strategy
 }
 
+func (a *Agent) HandleDonateToHpPool(agentState state.AgentState) uint {
+	// fmt.Print(agentState)
+	a.BaseAgent.latestState = agentState
+
+	return a.Strategy.DonateToHpPool(a.BaseAgent)
+}
+
+func (a *Agent) HandleUpdateInternalState(agentState state.AgentState, fightResults *commons.ImmutableList[decision.ImmutableFightResult], voteResults *immutable.Map[decision.Intent, uint]) {
+	a.BaseAgent.latestState = agentState
+
+	a.Strategy.UpdateInternalState(a.BaseAgent, fightResults, voteResults)
+}
+
 func (a *Agent) HandleUpdateWeapon(agentState state.AgentState, view state.View) decision.ItemIdx {
 	a.BaseAgent.latestState = agentState
 

--- a/pkg/infra/game/agent/strategy.go
+++ b/pkg/infra/game/agent/strategy.go
@@ -24,5 +24,6 @@ type Strategy interface {
 	HandleUpdateWeapon(view *state.View, baseAgent BaseAgent) decision.ItemIdx
 	// HandleUpdateShield return the index of the shield you want to use in AgentState.Shields
 	HandleUpdateShield(view *state.View, baseAgent BaseAgent) decision.ItemIdx
-	UpdateInternalState(fightResult *commons.ImmutableList[decision.ImmutableFightResult], voteResult *immutable.Map[decision.Intent, uint])
+	UpdateInternalState(baseAgent BaseAgent, fightResult *commons.ImmutableList[decision.ImmutableFightResult], voteResult *immutable.Map[decision.Intent, uint])
+	DonateToHpPool(baseAgent BaseAgent) uint
 }

--- a/pkg/infra/game/decision/decision.go
+++ b/pkg/infra/game/decision/decision.go
@@ -91,4 +91,9 @@ const (
 	BordaCount
 )
 
+type HpPoolDonation struct {
+	AgentID  commons.ID
+	Donation uint
+}
+
 type ItemIdx uint

--- a/pkg/infra/game/example/random.go
+++ b/pkg/infra/game/example/random.go
@@ -6,7 +6,6 @@ import (
 	"infra/game/decision"
 	"infra/game/message"
 	"infra/game/state"
-	"infra/logging"
 	"math/rand"
 
 	"github.com/benbjohnson/immutable"
@@ -17,7 +16,11 @@ type RandomAgent struct {
 	bravery int
 }
 
-func (r *RandomAgent) UpdateInternalState(fightResult *commons.ImmutableList[decision.ImmutableFightResult], voteResult *immutable.Map[decision.Intent, uint]) {
+func (r *RandomAgent) DonateToHpPool(baseAgent agent.BaseAgent) uint {
+	return uint(rand.Intn(int(baseAgent.AgentState().Hp)))
+}
+
+func (r *RandomAgent) UpdateInternalState(agent agent.BaseAgent, _ *commons.ImmutableList[decision.ImmutableFightResult], _ *immutable.Map[decision.Intent, uint]) {
 }
 
 func (r *RandomAgent) FightResolution(baseAgent agent.BaseAgent) message.MapProposal[decision.FightAction] {
@@ -62,7 +65,7 @@ func (r *RandomAgent) HandleConfidencePoll(_ agent.BaseAgent) decision.Intent {
 }
 
 func (r *RandomAgent) HandleFightInformation(_ message.TaggedMessage, baseAgent agent.BaseAgent, _ *immutable.Map[commons.ID, decision.FightAction]) {
-	baseAgent.Log(logging.Trace, logging.LogField{"bravery": r.bravery, "hp": baseAgent.AgentState().Hp}, "Cowering")
+	// baseAgent.Log(logging.Trace, logging.LogField{"bravery": r.bravery, "hp": baseAgent.AgentState().Hp}, "Cowering")
 	makesProposal := rand.Intn(100)
 
 	if makesProposal > 80 {

--- a/pkg/infra/game/stage/hppool/hpppol.go
+++ b/pkg/infra/game/stage/hppool/hpppol.go
@@ -13,15 +13,15 @@ func UpdateHpPool(agentMap map[commons.ID]agent.Agent, globalState *state.State)
 	var wg sync.WaitGroup
 	donationChan := make(chan decision.HpPoolDonation, len(agentMap))
 	for id, a := range agentMap {
-		// fmt.Print(a.BaseAgent.AgentState().Hp)
 		id := id
 		a := a
+		aState := globalState.AgentState[id]
 		wg.Add(1)
-		go func(wait *sync.WaitGroup, donationChan chan decision.HpPoolDonation) {
-			donation := a.HandleDonateToHpPool(globalState.AgentState[id])
+		go func(wait *sync.WaitGroup, donationChan chan decision.HpPoolDonation, agentState state.AgentState) {
+			donation := a.HandleDonateToHpPool(agentState)
 			donationChan <- decision.HpPoolDonation{AgentID: id, Donation: donation}
 			wait.Done()
-		}(&wg, donationChan)
+		}(&wg, donationChan, aState)
 	}
 
 	go func(wait *sync.WaitGroup) {

--- a/pkg/infra/game/stage/hppool/hpppol.go
+++ b/pkg/infra/game/stage/hppool/hpppol.go
@@ -1,0 +1,61 @@
+package hppool
+
+import (
+	"infra/game/agent"
+	"infra/game/commons"
+	"infra/game/decision"
+	"infra/game/state"
+	"infra/logging"
+	"sync"
+)
+
+func UpdateHpPool(agentMap map[commons.ID]agent.Agent, globalState *state.State) {
+	var wg sync.WaitGroup
+	donationChan := make(chan decision.HpPoolDonation, len(agentMap))
+	for id, a := range agentMap {
+		// fmt.Print(a.BaseAgent.AgentState().Hp)
+		id := id
+		a := a
+		wg.Add(1)
+		go func(wait *sync.WaitGroup, donationChan chan decision.HpPoolDonation) {
+			donation := a.HandleDonateToHpPool(globalState.AgentState[id])
+			donationChan <- decision.HpPoolDonation{AgentID: id, Donation: donation}
+			wait.Done()
+		}(&wg, donationChan)
+	}
+
+	go func(wait *sync.WaitGroup) {
+		wait.Wait()
+		close(donationChan)
+	}(&wg)
+
+	sum := uint(0)
+	for agentDonation := range donationChan {
+		agentHp := globalState.AgentState[agentDonation.AgentID].Hp
+		if agentDonation.Donation >= agentHp {
+			agentDonation.Donation = agentHp
+			delete(globalState.AgentState, agentDonation.AgentID)
+			delete(agentMap, agentDonation.AgentID)
+		}
+
+		logging.Log(logging.Trace, logging.LogField{
+			"Agent Donation": agentDonation,
+			"Old Sum":        sum,
+			"New Sum":        sum + agentDonation.Donation,
+		}, "HP Pool Donation")
+
+		sum += agentDonation.Donation
+		if a, ok := globalState.AgentState[agentDonation.AgentID]; ok {
+			a.Hp = agentHp - agentDonation.Donation
+			globalState.AgentState[agentDonation.AgentID] = a
+		}
+	}
+
+	logging.Log(logging.Info, logging.LogField{
+		"Old HP Pool":           globalState.HpPool,
+		"HP Donated This Round": sum,
+		"New Hp Pool":           globalState.HpPool + sum,
+	}, "HP Pool Donation")
+
+	globalState.HpPool += sum
+}

--- a/pkg/infra/main.go
+++ b/pkg/infra/main.go
@@ -53,6 +53,11 @@ func startGameLoop() {
 			termLeft, votes = runConfidenceVote(termLeft)
 		}
 
+		if globalState.HpPool >= globalState.MonsterHealth {
+			globalState.HpPool -= globalState.MonsterHealth
+			globalState.MonsterHealth = 0
+		}
+
 		// allow agents to change the weapon and the shield in use
 		updatedGlobalState := loot.UpdateItems(*globalState, agentMap)
 		globalState = &updatedGlobalState
@@ -117,6 +122,8 @@ func startGameLoop() {
 
 		newGlobalState := stages.AgentLootDecisions(*globalState, agentMap, weaponLoot, shieldLoot)
 		globalState = &newGlobalState
+
+		// TODO: HP Pool donations
 
 		// TODO: End of level Updates
 		termLeft--

--- a/pkg/infra/main.go
+++ b/pkg/infra/main.go
@@ -53,16 +53,7 @@ func startGameLoop() {
 			termLeft, votes = runConfidenceVote(termLeft)
 		}
 
-		if globalState.HpPool >= globalState.MonsterHealth {
-			logging.Log(logging.Info, logging.LogField{
-				"Original HP Pool":  globalState.HpPool,
-				"Monster Health":    globalState.MonsterHealth,
-				"HP Pool Remaining": globalState.HpPool - globalState.MonsterHealth,
-			}, fmt.Sprintf("Skipping level %d through HP Pool", globalState.CurrentLevel))
-
-			globalState.HpPool -= globalState.MonsterHealth
-			globalState.MonsterHealth = 0
-		}
+		checkHpPool()
 
 		// allow agents to change the weapon and the shield in use
 		updatedGlobalState := loot.UpdateItems(*globalState, agentMap)

--- a/pkg/infra/main.go
+++ b/pkg/infra/main.go
@@ -54,6 +54,12 @@ func startGameLoop() {
 		}
 
 		if globalState.HpPool >= globalState.MonsterHealth {
+			logging.Log(logging.Info, logging.LogField{
+				"Original HP Pool":  globalState.HpPool,
+				"Monster Health":    globalState.MonsterHealth,
+				"HP Pool Remaining": globalState.HpPool - globalState.MonsterHealth,
+			}, fmt.Sprintf("Skipping level %d through HP Pool", globalState.CurrentLevel))
+
 			globalState.HpPool -= globalState.MonsterHealth
 			globalState.MonsterHealth = 0
 		}
@@ -61,8 +67,6 @@ func startGameLoop() {
 		// allow agents to change the weapon and the shield in use
 		updatedGlobalState := loot.UpdateItems(*globalState, agentMap)
 		globalState = &updatedGlobalState
-
-		// TODO: Fight Discussion Stage
 
 		// Battle Rounds
 		// TODO: Ambiguity in specification - do agents have a upper limit of rounds to try and slay the monster?
@@ -124,6 +128,7 @@ func startGameLoop() {
 		globalState = &newGlobalState
 
 		// TODO: HP Pool donations
+		updateHpPool()
 
 		// TODO: End of level Updates
 		termLeft--

--- a/pkg/infra/main.go
+++ b/pkg/infra/main.go
@@ -119,7 +119,6 @@ func startGameLoop() {
 		newGlobalState := stages.AgentLootDecisions(*globalState, agentMap, weaponLoot, shieldLoot)
 		globalState = &newGlobalState
 
-		// TODO: HP Pool donations
 		hppool.UpdateHpPool(agentMap, globalState)
 
 		// TODO: End of level Updates

--- a/pkg/infra/main.go
+++ b/pkg/infra/main.go
@@ -10,6 +10,7 @@ import (
 	"infra/game/message"
 	"infra/game/stage/discussion"
 	"infra/game/stage/fight"
+	"infra/game/stage/hppool"
 	"infra/game/stage/loot"
 	"infra/game/stages"
 	"infra/logging"
@@ -119,7 +120,7 @@ func startGameLoop() {
 		globalState = &newGlobalState
 
 		// TODO: HP Pool donations
-		updateHpPool()
+		hppool.UpdateHpPool(agentMap, globalState)
 
 		// TODO: End of level Updates
 		termLeft--

--- a/pkg/infra/main_helper.go
+++ b/pkg/infra/main_helper.go
@@ -212,6 +212,8 @@ func updateHpPool() {
 		agentHp := globalState.AgentState[agentDonation.agentId].Hp
 		if agentDonation.donation > agentHp {
 			agentDonation.donation = agentHp
+			delete(globalState.AgentState, agentDonation.agentId)
+			delete(agentMap, agentDonation.agentId)
 		}
 
 		logging.Log(logging.Trace, logging.LogField{

--- a/pkg/infra/main_helper.go
+++ b/pkg/infra/main_helper.go
@@ -167,9 +167,26 @@ func updateInternalStates(immutableFightRounds *commons.ImmutableList[decision.I
 	wg.Wait()
 }
 
+/*
+	Hp Pool Helpers
+*/
+
 type HpPoolDonation struct {
 	agentId  commons.ID
 	donation uint
+}
+
+func checkHpPool() {
+	if globalState.HpPool >= globalState.MonsterHealth {
+		logging.Log(logging.Info, logging.LogField{
+			"Original HP Pool":  globalState.HpPool,
+			"Monster Health":    globalState.MonsterHealth,
+			"HP Pool Remaining": globalState.HpPool - globalState.MonsterHealth,
+		}, fmt.Sprintf("Skipping level %d through HP Pool", globalState.CurrentLevel))
+
+		globalState.HpPool -= globalState.MonsterHealth
+		globalState.MonsterHealth = 0
+	}
 }
 
 func updateHpPool() {

--- a/pkg/infra/main_helper.go
+++ b/pkg/infra/main_helper.go
@@ -177,14 +177,14 @@ type HpPoolDonation struct {
 }
 
 func checkHpPool() {
-	if globalState.HpPool >= globalState.MonsterHealth {
+	if globalState.HpPool >= globalState.MonsterAttack {
 		logging.Log(logging.Info, logging.LogField{
 			"Original HP Pool":  globalState.HpPool,
-			"Monster Health":    globalState.MonsterHealth,
-			"HP Pool Remaining": globalState.HpPool - globalState.MonsterHealth,
+			"Monster Damage":    globalState.MonsterAttack,
+			"HP Pool Remaining": globalState.HpPool - globalState.MonsterAttack,
 		}, fmt.Sprintf("Skipping level %d through HP Pool", globalState.CurrentLevel))
 
-		globalState.HpPool -= globalState.MonsterHealth
+		globalState.HpPool -= globalState.MonsterAttack
 		globalState.MonsterHealth = 0
 	}
 }

--- a/pkg/infra/main_helper.go
+++ b/pkg/infra/main_helper.go
@@ -210,7 +210,7 @@ func updateHpPool() {
 		agentDonation := <-donationChan
 
 		agentHp := globalState.AgentState[agentDonation.agentId].Hp
-		if agentDonation.donation > agentHp {
+		if agentDonation.donation >= agentHp {
 			agentDonation.donation = agentHp
 			delete(globalState.AgentState, agentDonation.agentId)
 			delete(agentMap, agentDonation.agentId)


### PR DESCRIPTION
Implements the HP Pool -without prior communication between agents and no leader imposition (and minor fix to update internal state).

- Hp pool is checked just before the fight rounds, at the start of each level. If `HpPool >= MonsterAttack` the fight rounds are skipped and monster attack value is deducted from hp pool
- At the end of each round, agents can choose to donate hp - this is checked against their max hp ( if they donate >= their max hp in `globalstate` they die)
- All other stages in each level happen as normal (vonc/election, loot etc)

**Observations:**
There might be something not quite right with the maths behind hp pool donation. We have 100 agents with 1000 HP each so we get around 50,000HP in the pool from the first level when the monster damage is around 1k. Through continuous donation they are able to skip all fight rounds until around lvl 40 when they die in 1 round because the hp pool is too small and they all have around 1-2hp left. Maybe we should cap hp pool donation or something?