### PR TITLE
[infra] Tidy up using Go generics

### DIFF
--- a/pkg/infra/game/agent/strategy.go
+++ b/pkg/infra/game/agent/strategy.go
@@ -10,8 +10,8 @@ import (
 )
 
 type Strategy interface {
-	HandleFightInformation(m message.TaggedMessage, baseAgent BaseAgent, log *immutable.Map[commons.ID, decision.FightAction])
-	HandleFightRequest(m message.TaggedMessage, log *immutable.Map[commons.ID, decision.FightAction]) message.FightInform
+	HandleFightInformation(m message.TaggedInformMessage[message.FightInform], baseAgent BaseAgent, log *immutable.Map[commons.ID, decision.FightAction])
+	HandleFightRequest(m message.TaggedRequestMessage[message.FightRequest], log *immutable.Map[commons.ID, decision.FightAction]) message.FightInform
 	CurrentAction() decision.FightAction
 	CreateManifesto(baseAgent BaseAgent) *decision.Manifesto
 	HandleConfidencePoll(baseAgent BaseAgent) decision.Intent

--- a/pkg/infra/game/example/random.go
+++ b/pkg/infra/game/example/random.go
@@ -64,7 +64,7 @@ func (r *RandomAgent) HandleConfidencePoll(_ agent.BaseAgent) decision.Intent {
 	}
 }
 
-func (r *RandomAgent) HandleFightInformation(_ message.TaggedMessage, baseAgent agent.BaseAgent, _ *immutable.Map[commons.ID, decision.FightAction]) {
+func (r *RandomAgent) HandleFightInformation(m message.TaggedInformMessage[message.FightInform], baseAgent agent.BaseAgent, log *immutable.Map[commons.ID, decision.FightAction]) {
 	// baseAgent.Log(logging.Trace, logging.LogField{"bravery": r.bravery, "hp": baseAgent.AgentState().Hp}, "Cowering")
 	makesProposal := rand.Intn(100)
 
@@ -74,7 +74,7 @@ func (r *RandomAgent) HandleFightInformation(_ message.TaggedMessage, baseAgent 
 	}
 }
 
-func (r *RandomAgent) HandleFightRequest(_ message.TaggedMessage, _ *immutable.Map[commons.ID, decision.FightAction]) message.FightInform {
+func (r *RandomAgent) HandleFightRequest(m message.TaggedRequestMessage[message.FightRequest], log *immutable.Map[commons.ID, decision.FightAction]) message.FightInform {
 	return nil
 }
 

--- a/pkg/infra/game/message/fight.go
+++ b/pkg/infra/game/message/fight.go
@@ -5,13 +5,16 @@ import (
 	"infra/game/decision"
 
 	"github.com/benbjohnson/immutable"
-	"github.com/google/uuid"
 )
 
 type FightProposalMessage struct {
 	sender     commons.ID
 	proposal   immutable.Map[commons.ID, decision.FightAction]
 	proposalID commons.ProposalID
+}
+
+func NewFightProposalMessage(sender commons.ID, proposal immutable.Map[commons.ID, decision.FightAction], proposalID commons.ProposalID) *FightProposalMessage {
+	return &FightProposalMessage{sender: sender, proposal: proposal, proposalID: proposalID}
 }
 
 func (f FightProposalMessage) sealedMessage() {
@@ -24,14 +27,4 @@ func (f FightProposalMessage) Proposal() immutable.Map[commons.ID, decision.Figh
 
 func (f FightProposalMessage) ProposalID() commons.ProposalID {
 	return f.proposalID
-}
-
-func NewFightProposalMessage(senderID commons.ID, proposal immutable.Map[commons.ID, decision.FightAction]) *FightProposalMessage {
-	newUuid, _ := uuid.NewUUID()
-
-	return &FightProposalMessage{
-		sender:     senderID,
-		proposal:   proposal,
-		proposalID: newUuid.String(),
-	}
 }

--- a/pkg/infra/game/message/message.go
+++ b/pkg/infra/game/message/message.go
@@ -30,6 +30,11 @@ type FightRequest interface {
 	sealedFightRequest()
 }
 
+type LootRequest interface {
+	Request
+	sealedLootRequest()
+}
+
 type FightInform interface {
 	Inform
 	sealedFightInform()
@@ -51,4 +56,46 @@ func (t TaggedMessage) Sender() commons.ID {
 
 func (t TaggedMessage) Message() Message {
 	return t.message
+}
+
+func (t TaggedMessage) MID() uuid.UUID {
+	return t.mID
+}
+
+type TaggedRequestMessage[R Request] struct {
+	sender  commons.ID
+	message R
+	mID     uuid.UUID
+}
+
+func NewTaggedRequestMessage[R Request](sender commons.ID, message R, mID uuid.UUID) *TaggedRequestMessage[R] {
+	return &TaggedRequestMessage[R]{sender: sender, message: message, mID: mID}
+}
+
+type TaggedInformMessage[I Inform] struct {
+	sender  commons.ID
+	message I
+	mID     uuid.UUID
+}
+
+func NewTaggedInformMessage[I Inform](sender commons.ID, message I, mID uuid.UUID) *TaggedInformMessage[I] {
+	return &TaggedInformMessage[I]{sender: sender, message: message, mID: mID}
+}
+
+type StartFight struct {
+}
+
+func (s StartFight) sealedMessage() {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (s StartFight) sealedInform() {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (s StartFight) sealedFightInform() {
+	//TODO implement me
+	panic("implement me")
 }

--- a/pkg/infra/game/stage/fight/fight.go
+++ b/pkg/infra/game/stage/fight/fight.go
@@ -61,7 +61,7 @@ func AgentFightDecisions(state state.State, agents map[commons.ID]agent.Agent, p
 	mID, _ := uuid.NewUUID()
 
 	for _, messages := range channelsMap {
-		messages <- *message.NewTaggedMessage("server", nil, mID)
+		messages <- *message.NewTaggedMessage("server", &message.StartFight{}, mID)
 	}
 	time.Sleep(100 * time.Millisecond)
 	for id, c := range channelsMap {


### PR DESCRIPTION
Makes the API for agent teams less type-casted

- Uses Go generics to avoid boilerplate in agent code
- Needs to migrate proposals to a newer system
- Maybe add some guards depending on "stage" to reduce bugs
