### PR TITLE
[Infra] Add custom messages for team experiments

### DIFF
--- a/pkg/infra/game/agent/agent.go
+++ b/pkg/infra/game/agent/agent.go
@@ -5,6 +5,7 @@ import (
 	"infra/game/commons"
 	"infra/game/decision"
 	"infra/game/message"
+	"infra/game/stages"
 	"infra/game/state"
 	"infra/logging"
 
@@ -111,6 +112,11 @@ func (a *Agent) handleMessage(log *immutable.Map[commons.ID, decision.FightActio
 		case decision.Positive:
 			votes <- v.ProposalID()
 		default:
+		}
+	case message.CustomInform:
+		if stages.Mode != "default" {
+			inf := *message.NewTaggedInformMessage[message.CustomInform](m.Sender(), r, m.MID())
+			a.Strategy.HandleCustomInformation(inf, a.BaseAgent, log)
 		}
 	default:
 		logging.Log(logging.Warn, nil, fmt.Sprintf("Unknown type, %T", r))

--- a/pkg/infra/game/agent/strategy.go
+++ b/pkg/infra/game/agent/strategy.go
@@ -26,4 +26,6 @@ type Strategy interface {
 	HandleUpdateShield(view *state.View, baseAgent BaseAgent) decision.ItemIdx
 	UpdateInternalState(baseAgent BaseAgent, fightResult *commons.ImmutableList[decision.ImmutableFightResult], voteResult *immutable.Map[decision.Intent, uint])
 	DonateToHpPool(baseAgent BaseAgent) uint
+	// Only implementable in team experiments
+	HandleCustomInformation(m message.TaggedInformMessage[message.CustomInform], baseAgent BaseAgent, log *immutable.Map[commons.ID, decision.FightAction])
 }

--- a/pkg/infra/game/example/random.go
+++ b/pkg/infra/game/example/random.go
@@ -150,6 +150,10 @@ func (r *RandomAgent) HandleUpdateShield(_ *state.View, _ agent.BaseAgent) decis
 	return decision.ItemIdx(0)
 }
 
+// Only implementable in team experiments
+func (r *RandomAgent) HandleCustomInformation(m message.TaggedInformMessage[message.CustomInform], baseAgent agent.BaseAgent, log *immutable.Map[commons.ID, decision.FightAction]) {
+}
+
 func NewRandomAgent() agent.Strategy {
 	return &RandomAgent{bravery: 0}
 }

--- a/pkg/infra/game/message/custom.go
+++ b/pkg/infra/game/message/custom.go
@@ -1,0 +1,26 @@
+package message
+
+type CustomPayload interface {
+	IsCustomPayload()
+}
+
+type CustomInfo struct {
+	payload CustomPayload
+}
+
+func (c CustomInfo) sealedMessage() {
+}
+
+func (c CustomInfo) sealedInform() {
+}
+
+func (c CustomInfo) sealedCustomInform() {
+}
+
+func (c CustomInfo) Payload() CustomPayload {
+	return c.payload
+}
+
+func NewCustomMessage(p CustomPayload) CustomInfo {
+	return CustomInfo{payload: p}
+}

--- a/pkg/infra/game/message/message.go
+++ b/pkg/infra/game/message/message.go
@@ -40,6 +40,11 @@ type FightInform interface {
 	sealedFightInform()
 }
 
+type CustomInform interface {
+	Inform
+	sealedCustomInform()
+}
+
 type TaggedMessage struct {
 	sender  commons.ID
 	message Message


### PR DESCRIPTION
In our team experiment, we intend to send private messages between agents that are not currently covered by the provided message types.

Hence this PR adds a message type with a payload that can be implemented by team files. The agent handler function for this message is only called if the game is not running in default mode