### PR TITLE
[Infra] Make UpdateInternalState overridable

### DIFF
--- a/pkg/infra/game/stage/update/update.go
+++ b/pkg/infra/game/stage/update/update.go
@@ -1,0 +1,25 @@
+package update
+
+import (
+	"infra/game/agent"
+	"infra/game/commons"
+	"infra/game/decision"
+	"infra/game/state"
+	"sync"
+
+	"github.com/benbjohnson/immutable"
+)
+
+func UpdateInternalStates(agentMap map[commons.ID]agent.Agent, globalState *state.State, immutableFightRounds *commons.ImmutableList[decision.ImmutableFightResult], votesResult *immutable.Map[decision.Intent, uint]) {
+	var wg sync.WaitGroup
+	for id, a := range agentMap {
+		id := id
+		a := a
+		wg.Add(1)
+		go func(wait *sync.WaitGroup) {
+			a.HandleUpdateInternalState(globalState.AgentState[id], immutableFightRounds, votesResult)
+			wait.Done()
+		}(&wg)
+	}
+	wg.Wait()
+}

--- a/pkg/infra/game/stages/stages.go
+++ b/pkg/infra/game/stages/stages.go
@@ -9,6 +9,7 @@ import (
 	"infra/game/stage/fight"
 	"infra/game/stage/initialise"
 	"infra/game/stage/loot"
+	"infra/game/stage/update"
 	"infra/game/state"
 	"infra/game/tally"
 	t0 "infra/teams/team0"
@@ -61,4 +62,15 @@ func AgentFightDecisions(state state.State, agents map[commons.ID]agent.Agent, p
 	default:
 		return fight.AgentFightDecisions(state, agents, previousDecisions, channelsMap)
 	}
+}
+
+func UpdateInternalStates(agentMap map[commons.ID]agent.Agent, globalState *state.State, immutableFightRounds *commons.ImmutableList[decision.ImmutableFightResult], votesResult *immutable.Map[decision.Intent, uint]) {
+	switch Mode {
+	// case "0":
+
+	default:
+		update.UpdateInternalStates(agentMap, globalState, immutableFightRounds, votesResult)
+	}
+
+	return
 }

--- a/pkg/infra/main.go
+++ b/pkg/infra/main.go
@@ -125,7 +125,7 @@ func startGameLoop() {
 
 		immutableFightRounds := commons.NewImmutableList(fightResultSlice)
 		votesResult := commons.MapToImmutable(votes)
-		updateInternalStates(immutableFightRounds, &votesResult)
+		stages.UpdateInternalStates(agentMap, globalState, immutableFightRounds, &votesResult)
 	}
 	logging.Log(logging.Info, nil, fmt.Sprintf("Congratulations, The Peasants have escaped the pit with %d remaining.", len(agentMap)))
 }

--- a/pkg/infra/main_helper.go
+++ b/pkg/infra/main_helper.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math/rand"
 	"sort"
-	"sync"
 
 	"github.com/google/uuid"
 
@@ -154,20 +153,6 @@ func damageCalculation(fightRoundResult decision.FightResult) {
 		fight.DealDamage(damageTaken, fightRoundResult.CoweringAgents, agentMap, globalState)
 	}
 	*viewPtr = globalState.ToView()
-}
-
-func updateInternalStates(immutableFightRounds *commons.ImmutableList[decision.ImmutableFightResult], votesResult *immutable.Map[decision.Intent, uint]) {
-	var wg sync.WaitGroup
-	for id, a := range agentMap {
-		id := id
-		a := a
-		wg.Add(1)
-		go func(wait *sync.WaitGroup) {
-			a.HandleUpdateInternalState(globalState.AgentState[id], immutableFightRounds, votesResult)
-			wait.Done()
-		}(&wg)
-	}
-	wg.Wait()
 }
 
 /*


### PR DESCRIPTION
Allows for more control over logging and data collection for team experiments. For example, accessing the global state values and actual stats of all agents.