### PR TITLE
[infra] Refactor & add preemptive allocations

### DIFF
--- a/pkg/infra/game/agent/agent.go
+++ b/pkg/infra/game/agent/agent.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"fmt"
-
 	"infra/game/commons"
 	"infra/game/decision"
 	"infra/game/message"

--- a/pkg/infra/game/agent/election.go
+++ b/pkg/infra/game/agent/election.go
@@ -1,0 +1,11 @@
+package agent
+
+import (
+	"infra/game/decision"
+)
+
+type Election interface {
+	CreateManifesto(baseAgent BaseAgent) *decision.Manifesto
+	HandleConfidencePoll(baseAgent BaseAgent) decision.Intent
+	HandleElectionBallot(baseAgent BaseAgent, params *decision.ElectionParams) decision.Ballot
+}

--- a/pkg/infra/game/agent/fight.go
+++ b/pkg/infra/game/agent/fight.go
@@ -1,0 +1,21 @@
+package agent
+
+import (
+	"infra/game/commons"
+	"infra/game/decision"
+	"infra/game/message"
+	"infra/game/message/proposal"
+
+	"github.com/benbjohnson/immutable"
+)
+
+type Fight interface {
+	HandleFightInformation(m message.TaggedInformMessage[message.FightInform], baseAgent BaseAgent, log *immutable.Map[commons.ID, decision.FightAction])
+	HandleFightRequest(m message.TaggedRequestMessage[message.FightRequest], log *immutable.Map[commons.ID, decision.FightAction]) message.FightInform
+	FightResolution(baseAgent BaseAgent, prop commons.ImmutableList[proposal.Rule[decision.FightAction]], proposedActions immutable.Map[commons.ID, decision.FightAction]) immutable.Map[commons.ID, decision.FightAction]
+	HandleFightProposal(proposal message.Proposal[decision.FightAction], baseAgent BaseAgent) decision.Intent
+	// HandleFightProposalRequest only called as leader
+	HandleFightProposalRequest(proposal message.Proposal[decision.FightAction], baseAgent BaseAgent, log *immutable.Map[commons.ID, decision.FightAction]) bool
+	FightActionNoProposal(baseAgent BaseAgent) decision.FightAction
+	FightAction(baseAgent BaseAgent, proposedAction decision.FightAction, acceptedProposal message.Proposal[decision.FightAction]) decision.FightAction
+}

--- a/pkg/infra/game/agent/hppool.go
+++ b/pkg/infra/game/agent/hppool.go
@@ -1,0 +1,5 @@
+package agent
+
+type HPPool interface {
+	DonateToHpPool(baseAgent BaseAgent) uint
+}

--- a/pkg/infra/game/agent/loot.go
+++ b/pkg/infra/game/agent/loot.go
@@ -1,0 +1,23 @@
+package agent
+
+import (
+	"infra/game/commons"
+	"infra/game/decision"
+	"infra/game/message"
+
+	"github.com/benbjohnson/immutable"
+)
+
+type Loot interface {
+	HandleLootInformation(m message.TaggedInformMessage[message.LootInform], baseAgent BaseAgent)
+	HandleLootRequest(m message.TaggedRequestMessage[message.LootRequest]) message.LootInform
+	HandleLootProposal(r message.Proposal[decision.LootAction], baseAgent BaseAgent) decision.Intent
+	HandleLootProposalRequest(proposal message.Proposal[decision.LootAction], baseAgent BaseAgent) bool
+	LootAllocation(
+		baseAgent BaseAgent,
+		proposal message.Proposal[decision.LootAction],
+		proposedAllocations immutable.Map[commons.ID, immutable.SortedMap[commons.ItemID, struct{}]],
+	) immutable.Map[commons.ID, immutable.SortedMap[commons.ItemID, struct{}]]
+	LootActionNoProposal(baseAgent BaseAgent) immutable.SortedMap[commons.ItemID, struct{}]
+	LootAction(baseAgent BaseAgent, proposedLoot immutable.SortedMap[commons.ItemID, struct{}], acceptedProposal message.Proposal[decision.LootAction]) immutable.SortedMap[commons.ItemID, struct{}]
+}

--- a/pkg/infra/game/agent/strategy.go
+++ b/pkg/infra/game/agent/strategy.go
@@ -3,8 +3,6 @@ package agent
 import (
 	"infra/game/commons"
 	"infra/game/decision"
-	"infra/game/message"
-	"infra/game/message/proposal"
 	"infra/logging"
 
 	"github.com/benbjohnson/immutable"
@@ -22,40 +20,4 @@ type Strategy interface {
 	HandleUpdateShield(baseAgent BaseAgent) decision.ItemIdx
 
 	UpdateInternalState(baseAgent BaseAgent, fightResult *commons.ImmutableList[decision.ImmutableFightResult], voteResult *immutable.Map[decision.Intent, uint], logChan chan<- logging.AgentLog)
-}
-
-type Election interface {
-	CreateManifesto(baseAgent BaseAgent) *decision.Manifesto
-	HandleConfidencePoll(baseAgent BaseAgent) decision.Intent
-	HandleElectionBallot(baseAgent BaseAgent, params *decision.ElectionParams) decision.Ballot
-}
-
-type Fight interface {
-	HandleFightInformation(m message.TaggedInformMessage[message.FightInform], baseAgent BaseAgent, log *immutable.Map[commons.ID, decision.FightAction])
-	HandleFightRequest(m message.TaggedRequestMessage[message.FightRequest], log *immutable.Map[commons.ID, decision.FightAction]) message.FightInform
-	FightResolution(agent BaseAgent, prop commons.ImmutableList[proposal.Rule[decision.FightAction]]) immutable.Map[commons.ID, decision.FightAction]
-	HandleFightProposal(proposal message.Proposal[decision.FightAction], baseAgent BaseAgent) decision.Intent
-	// HandleFightProposalRequest only called as leader
-	HandleFightProposalRequest(proposal message.Proposal[decision.FightAction], baseAgent BaseAgent, log *immutable.Map[commons.ID, decision.FightAction]) bool
-	FightActionNoProposal(baseAgent BaseAgent) decision.FightAction
-	FightAction(baseAgent BaseAgent, proposedAction decision.FightAction, acceptedProposal message.Proposal[decision.FightAction]) decision.FightAction
-}
-
-type Loot interface {
-	HandleLootInformation(m message.TaggedInformMessage[message.LootInform], agent BaseAgent)
-	HandleLootRequest(m message.TaggedRequestMessage[message.LootRequest]) message.LootInform
-	HandleLootProposal(r message.Proposal[decision.LootAction], agent BaseAgent) decision.Intent
-	HandleLootProposalRequest(proposal message.Proposal[decision.LootAction], agent BaseAgent) bool
-	LootAllocation(baseAgent BaseAgent, proposal message.Proposal[decision.LootAction]) immutable.Map[commons.ID, immutable.SortedMap[commons.ItemID, struct{}]]
-	LootActionNoProposal(baseAgent BaseAgent) immutable.SortedMap[commons.ItemID, struct{}]
-	LootAction(baseAgent BaseAgent, proposedLoot immutable.SortedMap[commons.ItemID, struct{}], acceptedProposal message.Proposal[decision.LootAction]) immutable.SortedMap[commons.ItemID, struct{}]
-}
-
-type HPPool interface {
-	DonateToHpPool(baseAgent BaseAgent) uint
-}
-
-type Trade interface {
-	// HandleTradeNegotiation given a map of trade negotiations, respond to one of them or start a new trade negotiation
-	HandleTradeNegotiation(agent BaseAgent, Info message.TradeInfo) message.TradeMessage
 }

--- a/pkg/infra/game/agent/trade.go
+++ b/pkg/infra/game/agent/trade.go
@@ -1,0 +1,10 @@
+package agent
+
+import (
+	"infra/game/message"
+)
+
+type Trade interface {
+	// HandleTradeNegotiation given a map of trade negotiations, respond to one of them or start a new trade negotiation
+	HandleTradeNegotiation(baseAgent BaseAgent, Info message.TradeInfo) message.TradeMessage
+}

--- a/pkg/infra/game/example/random.go
+++ b/pkg/infra/game/example/random.go
@@ -17,7 +17,11 @@ type RandomAgent struct {
 	bravery int
 }
 
-func (r *RandomAgent) FightResolution(agent agent.BaseAgent, _ commons.ImmutableList[proposal.Rule[decision.FightAction]]) immutable.Map[commons.ID, decision.FightAction] {
+func (r *RandomAgent) FightResolution(
+	agent agent.BaseAgent,
+	prop commons.ImmutableList[proposal.Rule[decision.FightAction]],
+	proposedActions immutable.Map[commons.ID, decision.FightAction],
+) immutable.Map[commons.ID, decision.FightAction] {
 	view := agent.View()
 	builder := immutable.NewMapBuilder[commons.ID, decision.FightAction](nil)
 	for _, id := range commons.ImmutableMapKeys(view.AgentState()) {
@@ -130,7 +134,11 @@ func (r *RandomAgent) HandleLootProposalRequest(_ message.Proposal[decision.Loot
 	}
 }
 
-func (r *RandomAgent) LootAllocation(baseAgent agent.BaseAgent, proposal message.Proposal[decision.LootAction]) immutable.Map[commons.ID, immutable.SortedMap[commons.ItemID, struct{}]] {
+func (r *RandomAgent) LootAllocation(
+	baseAgent agent.BaseAgent,
+	proposal message.Proposal[decision.LootAction],
+	proposedAllocation immutable.Map[commons.ID, immutable.SortedMap[commons.ItemID, struct{}]],
+) immutable.Map[commons.ID, immutable.SortedMap[commons.ItemID, struct{}]] {
 	lootAllocation := make(map[commons.ID][]commons.ItemID)
 	view := baseAgent.View()
 	ids := commons.ImmutableMapKeys(view.AgentState())

--- a/pkg/infra/teams/team1/team1_agent.go
+++ b/pkg/infra/teams/team1/team1_agent.go
@@ -29,7 +29,11 @@ type SocialAgent struct {
 	graphID int // for logging
 }
 
-func (s *SocialAgent) FightResolution(agent agent.BaseAgent, prop commons.ImmutableList[proposal.Rule[decision.FightAction]]) immutable.Map[commons.ID, decision.FightAction] {
+func (s *SocialAgent) FightResolution(
+	agent agent.BaseAgent,
+	prop commons.ImmutableList[proposal.Rule[decision.FightAction]],
+	proposedActions immutable.Map[commons.ID, decision.FightAction],
+) immutable.Map[commons.ID, decision.FightAction] {
 	view := agent.View()
 	builder := immutable.NewMapBuilder[commons.ID, decision.FightAction](nil)
 	for _, id := range commons.ImmutableMapKeys(view.AgentState()) {
@@ -115,7 +119,11 @@ func (s *SocialAgent) HandleLootProposalRequest(_ message.Proposal[decision.Loot
 	}
 }
 
-func (s *SocialAgent) LootAllocation(ba agent.BaseAgent, proposal message.Proposal[decision.LootAction]) immutable.Map[commons.ID, immutable.SortedMap[commons.ItemID, struct{}]] {
+func (s *SocialAgent) LootAllocation(
+	ba agent.BaseAgent,
+	proposal message.Proposal[decision.LootAction],
+	proposedAllocations immutable.Map[commons.ID, immutable.SortedMap[commons.ItemID, struct{}]],
+) immutable.Map[commons.ID, immutable.SortedMap[commons.ItemID, struct{}]] {
 	lootAllocation := make(map[commons.ID][]commons.ItemID)
 	view := ba.View()
 	ids := commons.ImmutableMapKeys(view.AgentState())


### PR DESCRIPTION
Adds infra calculated allocation for leaders

- Leaders can use allocations to follow prop
- Enables for strict adherence to the proposal
