### PR TITLE
[Infra] Trading: Allow agents to gift items

### DIFF
--- a/pkg/infra/game/message/negotiation.go
+++ b/pkg/infra/game/message/negotiation.go
@@ -98,7 +98,7 @@ func (negotiation *TradeNegotiation) Notarize(agents map[commons.ID]state.AgentS
 		}
 	}
 
-	return numberOfValidAgents == 2 && negotiation.RoundNum > 1
+	return numberOfValidAgents == 2 && negotiation.RoundNum >= 1
 }
 
 func (negotiation *TradeNegotiation) UpdateOffer(agentID commons.ID, offer TradeOffer) (oldOffer TradeOffer, ok bool) {


### PR DESCRIPTION
Currently agents have to make an offer, send another offer, then accept in order for a trade to be accepted. However, a trade does not execute if an agent gifts an item to another agent who accepts in immediately in the next round (round 1).