### PR TITLE
fix NewTradeOffer when idx == inventory size

### DIFF
--- a/pkg/infra/game/message/trade.go
+++ b/pkg/infra/game/message/trade.go
@@ -82,7 +82,7 @@ func NewTradeOffer(itemType commons.ItemType, idx uint, weapon immutable.List[st
 	} else if itemType == commons.Shield {
 		inventory = shield
 	}
-	if idx > uint(inventory.Len()) {
+	if idx >= uint(inventory.Len()) {
 		return TradeOffer{}, false
 	}
 	item := inventory.Get(int(idx))


### PR DESCRIPTION
The current implementation of NewTradeOffer will panic when given idx == size of inventory.
This bug will be fixed by this PR.